### PR TITLE
Feature/include google closure dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dart_compressed.js
 javascript_compressed.js
 php_compressed.js
 python_compressed.js
+build

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,7 +4,7 @@
  * COINS Front-End Gruntfile.
  * @module
  *
- * @todo Use of Grunt will be removed in a future version coins_core in favor of
+ * @todo Use of Grunt will be removed in a future version blocky in favor of
  * using npm scripts and composer directly. See:
  * {@link https://github.com/MRN-Code/coins_core/pull/329}
  *
@@ -14,12 +14,19 @@
  * @param {Grunt} grunt
  */
 module.exports = function (grunt) {
-    console.error(`🚨  Use of Grunt will be removed in a future version coins_core in favor of using npm scripts and composer directly. See: https://github.com/MRN-Code/coins_core/pull/329`);
+    console.error(`🚨  Use of Grunt will be removed in a future version blocky in favor of using npm scripts and composer directly. See: https://github.com/MRN-Code/coins_core/pull/329`);
 
     require('time-grunt')(grunt);
     require('load-grunt-tasks')(grunt);
-    require('load-grunt-config')(grunt);
+    grunt.initConfig({
+        exec: {
+          build: {
+            command: 'npm run build',
+          },
+        },
+        pkg: grunt.file.readJSON('package.json'),
+    });
 
-    grunt.registerTask('build', { command: 'npm run build' });
+    grunt.registerTask('build', ['exec:build']);
     grunt.registerTask('default', ['build']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,9 +1,25 @@
 'use strict';
+
+/**
+ * COINS Front-End Gruntfile.
+ * @module
+ *
+ * @todo Use of Grunt will be removed in a future version coins_core in favor of
+ * using npm scripts and composer directly. See:
+ * {@link https://github.com/MRN-Code/coins_core/pull/329}
+ *
+ * {@link https://gruntjs.com/getting-started}
+ * {@link https://www.npmjs.com/package/grunt-exec}
+ *
+ * @param {Grunt} grunt
+ */
 module.exports = function (grunt) {
+    console.error(`🚨  Use of Grunt will be removed in a future version coins_core in favor of using npm scripts and composer directly. See: https://github.com/MRN-Code/coins_core/pull/329`);
+
     require('time-grunt')(grunt);
     require('load-grunt-tasks')(grunt);
     require('load-grunt-config')(grunt);
 
-    grunt.registerTask('build', ['exec:build']);
+    grunt.registerTask('build', { command: 'npm run build' });
     grunt.registerTask('default', ['build']);
 };

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # COINS Blockly
-Forked copy of google's [blocky](https://developers.google.com/blockly) project with some tweaks for use in the rdoc tool
+Forked copy of google's [blocky](https://developers.google.com/blockly) project with some modifications for use in the [rdoc tool](https://github.com/MRN-Code/asmt/blob/develop/instruments/rdocQMapping.php#L131)
 
 ## Upstream source
 Google's Blockly is a web-based, visual programming editor.  Users can drag
@@ -16,7 +16,7 @@ blocks together to build programs.  All code is free and open source.
 ## Internal Dependencies
 - The blockly project is built using the google [closure](https://developers.google.com/closure/) tool kit which is required when building this project. 
 - This dependancy is met via the included npm package [google-closure-library](https://www.npmjs.com/package/google-closure-library) however the blocky project expects the closure source files to be located in it's own project folder.
-- To accommodate this requirement there is a postinstall step which creates a symlink in the expected path which points back to the installed npm module.
+- To accommodate this requirement there is a [postinstall step](package.json#L24) which creates a symlink in the expected path which points back to the installed npm module.
 
 ## Usage
 ```
@@ -25,4 +25,4 @@ npm run build
 ```
 
 ## Output
-- The minified js bundle can be found in `build/js/blockly.bundle.js`
+- The minified js bundle can be found in `build/js/coins-blockly.js`

--- a/README.md
+++ b/README.md
@@ -1,8 +1,28 @@
-# Blockly
+# COINS Blockly
+Forked copy of google's [blocky](https://developers.google.com/blockly) project with some tweaks for use in the rdoc tool
 
+## Upstream source
 Google's Blockly is a web-based, visual programming editor.  Users can drag
 blocks together to build programs.  All code is free and open source.
 
 **The project page is https://developers.google.com/blockly/**
 
-![](https://developers.google.com/blockly/sample.png)
+![](https://developers.google.com/blockly/images/sample.png)
+
+## External Dependencies
+- python2.7
+- unix system
+
+## Internal Dependencies
+- The blockly project is built using the google [closure](https://developers.google.com/closure/) tool kit which is required when building this project. 
+- This dependancy is met via the included npm package [google-closure-library](https://www.npmjs.com/package/google-closure-library) however the blocky project expects the closure source files to be located in it's own project folder.
+- To accommodate this requirement there is a postinstall step which creates a symlink in the expected path which points back to the installed npm module.
+
+## Usage
+```
+npm i
+npm run build
+```
+
+## Output
+- The minified js bundle can be found in `build/js/blockly.bundle.js`

--- a/bundle.sh
+++ b/bundle.sh
@@ -4,9 +4,11 @@
 umask 002
 
 #make build dir
+echo "Creating build/js dir"
 mkdir -p build/js
 
 #bundle up pre-minify js
+echo "Creating bundle.."
 cat \
   "blockly_compressed.js" \
   "blocks_compressed.js" \
@@ -15,3 +17,4 @@ cat \
   "php_compressed.js" \
   "msg/js/en.js" \
   > build/js/blockly.bundle.js
+echo "SUCCESS: build/js/blockly.bundle.js"

--- a/bundle.sh
+++ b/bundle.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+#run as normal user
+umask 002
+
+#make build dir
+mkdir -p build/js
+
+#bundle up pre-minify js
+cat \
+  "blockly_compressed.js" \
+  "blocks_compressed.js" \
+  "blocks/coins.js" \
+  "javascript_compressed.js" \
+  "php_compressed.js" \
+  "msg/js/en.js" \
+  > build/js/blockly.bundle.js

--- a/bundle.sh
+++ b/bundle.sh
@@ -7,7 +7,7 @@ umask 002
 echo "Creating build/js dir"
 mkdir -p build/js
 
-#bundle up pre-minify js
+#bundle js
 echo "Creating bundle.."
 cat \
   "blockly_compressed.js" \
@@ -16,5 +16,5 @@ cat \
   "javascript_compressed.js" \
   "php_compressed.js" \
   "msg/js/en.js" \
-  > build/js/blockly.bundle.js
-echo "SUCCESS: build/js/blockly.bundle.js"
+  > build/js/coins-blockly.js
+echo "SUCCESS: build/js/coins-blockly.js"

--- a/msg/json/en.json
+++ b/msg/json/en.json
@@ -1,7 +1,7 @@
 {
 	"@metadata": {
 		"author": "Ellen Spertus <ellen.spertus@gmail.com>",
-		"lastupdated": "2016-09-26 18:18:05.388794",
+		"lastupdated": "2017-12-19 09:19:18.494937",
 		"locale": "en",
 		"messagedocumentation" : "qqq"
 	},

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "time-grunt": "1.2.1"
   },
   "scripts": {
-    "build": "./build.py",
+    "build": "./build.py && ./bundle.sh",
     "postinstall": "ln -s $(npm root)/google-closure-library ../closure-library",
     "lint": "echo 'run linter!'",
     "validate": "echo 'run validator!'",

--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
     "test": "test"
   },
   "dependencies": {
-    "google-closure-library": "^20170910.0.0"
+    "google-closure-library": "20170910.0.0"
   },
   "devDependencies": {
     "coins-grunt-env": "*",
     "grunt": "0.4.5",
     "grunt-env": "0.4.4",
-    "grunt-exec": "^0.4.6",
+    "grunt-exec": "0.4.6",
     "load-grunt-config": "0.17.2",
     "load-grunt-tasks": "3.2.0",
     "precommit-hook": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "build": "./build.py && ./bundle.sh",
-    "postinstall": "ln -s $(npm root)/google-closure-library ../closure-library",
+    "postinstall": "ln -sfn $(npm root)/google-closure-library ../closure-library",
     "lint": "echo 'run linter!'",
     "validate": "echo 'run validator!'",
     "test": "grunt test"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "dependencies": {
+    "google-closure-library": "^20170910.0.0"
   },
   "devDependencies": {
     "coins-grunt-env": "*",
@@ -19,6 +20,8 @@
     "time-grunt": "1.2.1"
   },
   "scripts": {
+    "build": "./build.py",
+    "postinstall": "ln -s $(npm root)/google-closure-library ../closure-library",
     "lint": "echo 'run linter!'",
     "validate": "echo 'run validator!'",
     "test": "grunt test"


### PR DESCRIPTION
#### Asana
Link to asana task
https://app.asana.com/0/162113178729864/511080929629604

# Other PRs
https://github.com/MRN-Code/coins_core/pull/371
https://github.com/MRN-Code/asmt/pull/328

# Problem
- Blocky's dependancies aren't documented in the repo
- Build requires an externally installed closure project
- Bundling logic is defined in coins_core instead of this repo 

# Research to do
- Is asmt the only consumer of this js bundle? We might consider importing this library directly via asmt to simplify coins_core build requirements.
- Should we make this an npm package? 🤷‍♂️ 

# Research Answers
-  blockly is only [required once](https://github.com/MRN-Code/asmt/blob/develop/instruments/rdocQMapping.php#L131) in asmt for use solely in the rdoc tool
- decided to just commit the pre-built bundle into `/coins_core/js/vendors/`

# Solution
- Add google-closure-library npm dependancy
- Add symlink in a post install step to make it available to blocky in the expected location
- Migrated bundle logic into this project