### PR TITLE
use https for google closure api calls

### DIFF
--- a/build.py
+++ b/build.py
@@ -248,7 +248,7 @@ class Gen_compressed(threading.Thread):
   def do_compile(self, params, target_filename, filenames, remove):
     # Send the request to Google.
     headers = {"Content-type": "application/x-www-form-urlencoded"}
-    conn = httplib.HTTPConnection("closure-compiler.appspot.com")
+    conn = httplib.HTTPSConnection("closure-compiler.appspot.com")
     conn.request("POST", "/compile", urllib.urlencode(params), headers)
     response = conn.getresponse()
     json_str = response.read()


### PR DESCRIPTION
# Problem 
- Blocky builds are failing https://github.com/MRN-Code/blockly/issues/5

# Issue
- Google is now requiring api calls to use HTTPS https://github.com/google/blockly/issues/1399

# Solution
- make api calls with HTTPS class